### PR TITLE
Only apply this to hook functions!

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ module.exports = babel => {
   const { types: t } = babel;
 
   return {
-    name: "class-to-function", // not required
+    name: "numeric-keys-array-destructure",
     visitor: {
       VariableDeclarator(path) {
-        if (t.isArrayPattern(path.node.id)) {
+        if (t.isArrayPattern(path.node.id) && t.isCallExpression(path.node.init) && path.node.init.callee.name.match(/^use[A-Z]/)) {
           path.node.id = t.objectPattern(
             path.node.id.elements.map((element, i) =>
               t.objectProperty(t.numericLiteral(i), element)


### PR DESCRIPTION
It works! https://astexplorer.net/#/gist/83a0e5fcd4106aa17351da3cecc4c974/65409cef508c6b75d55767d20288a4af384687d2

This makes it so the plugin only converts hooks:

**input:**

```js
function Foo() {
  // this gets converted to object destructuring:
  const [count, setCount] = useState(0);

  // but non-hook calls are not modified:
  const [a, b] = [0, 1];
  const [c, d] = otherThings();
  const f = 0;
}
```

**output:**

```js
function Foo() {
  // this gets converted to object destructuring:
  const {
    0: count,
    1: setCount
  } = useState(0);

  // but non-hook calls are not modified:
  const [a, b] = [0, 1];
  const [c, d] = otherThings();
  const f = 0;
}
```