### PR TITLE
Options for import and hook name allow lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,47 @@
-module.exports = babel => {
+// matches any hook-like (the default)
+const isHook = /^use[A-Z]/;
+
+// matches only built-in hooks provided by React et al
+const isBuiltInHook = /^use(Callback|Context|DebugValue|Effect|ImperativeHandle|LayoutEffect|Memo|Reducer|Ref|State)$/;
+
+module.exports = (babel, options) => {
+
   const { types: t } = babel;
-  const isHook = /^use[A-Z]/;
+  const onlyBuiltIns = options && options.onlyBuiltIns;
+
+  // if specified, options.lib is a list of libraries that provide hook functions
+  const libs = options && options.lib && (
+    options.lib === true ? ['react', 'preact/hooks'] : [].concat(options.lib)
+  );
 
   return {
     name: "optimize-hook-destructuring",
     visitor: {
       CallExpression(path) {
-        if (isHook.test(path.node.callee.name) && t.isArrayPattern(path.parent.id)) {
-          path.parent.id = t.objectPattern(
-            path.parent.id.elements.map((element, i) =>
-              t.objectProperty(t.numericLiteral(i), element)
-            )
-          );
+        // skip function calls where the return value is not Array-destructured:
+        if (!t.isArrayPattern(path.parent.id)) return;
+
+        // name of the (hook) function being called:
+        const hookName = path.node.callee.name;
+
+        if (libs) {
+          const binding = path.scope.getBinding(hookName);
+          // not an import
+          if (!binding || binding.kind !== 'module') return;
+
+          const specifier = binding.path.parent.source.value;
+          // not a match
+          if (!libs.some(lib => lib === specifier)) return;
         }
+        
+        // only match function calls with names that look like a hook
+        if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
+        
+        path.parent.id = t.objectPattern(
+          path.parent.id.elements.map((element, i) =>
+            t.objectProperty(t.numericLiteral(i), element)
+          )
+        );
       }
     }
   };

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 module.exports = babel => {
   const { types: t } = babel;
+  const isHook = /^use[A-Z]/;
 
   return {
     name: "optimize-hook-destructuring",
     visitor: {
-      VariableDeclarator(path) {
-        if (t.isArrayPattern(path.node.id) && t.isCallExpression(path.node.init) && path.node.init.callee.name.match(/^use[A-Z]/)) {
-          path.node.id = t.objectPattern(
-            path.node.id.elements.map((element, i) =>
+      CallExpression(path) {
+        if (isHook.test(path.node.callee.name) && t.isArrayPattern(path.parent.id)) {
+          path.parent.id = t.objectPattern(
+            path.parent.id.elements.map((element, i) =>
               t.objectProperty(t.numericLiteral(i), element)
             )
           );


### PR DESCRIPTION
Add options for controlling which function invocations are considered to be hooks, including import specifier lookup.

You can see a [detailed example on ASTExplorer](https://astexplorer.net/#/gist/5d04c951c759f80a5f9a02883b831f80/92cb9b211e424fa40fa0820e3be80150a0e43c71).

```js
["babel-plugin-optimize-hook-destructuring", {
  // only transform known React/Preact hooks:
  onlyBuiltIns: true
}]
```

```js
["babel-plugin-optimize-hook-destructuring", {
  // only transform hook functions imported from "react" or "preact/hooks"
  lib: true
}]
```

```js
["babel-plugin-optimize-hook-destructuring", {
  // only transform hook functions imported from the listed module names
  lib: ["my-awesome-hooks-lib", "react"]
}]
```

_**Note:** includes #3_