### PR TITLE
Backport changes from Next.js / Gatsby forks

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = ({ types: t }, /** @type {Options} */ options = {}) => {
 			// this is a workaround to run before preset-env destroys destructured assignments
 			Program(path) {
 				path.traverse(visitor);
-			},
-		},
+			}
+		}
 	};
 };

--- a/index.js
+++ b/index.js
@@ -16,54 +16,54 @@ const isBuiltInHook = /^use(?:Callback|Context|DebugValue|Effect|ImperativeHandl
  * @returns {import('@babel/core').PluginObj}
  */
 module.exports = ({ types: t }, /** @type {Options} */ options = {}) => {
-	const libs = options.lib && (options.lib === true ? ['react', 'preact/hooks'] : [options.lib]);
-	const onlyBuiltIns = options.onlyBuiltIns || false;
+  const libs = options.lib && (options.lib === true ? ['react', 'preact/hooks'] : [options.lib]);
+  const onlyBuiltIns = options.onlyBuiltIns || false;
 
-	/** @type {import('@babel/core').Visitor} */
-	const visitor = {
-		CallExpression(path) {
-			// skip function calls that are not the init of a variable declaration:
-			if (!t.isVariableDeclarator(path.parent)) return;
+  /** @type {import('@babel/core').Visitor} */
+  const visitor = {
+    CallExpression(path) {
+      // skip function calls that are not the init of a variable declaration:
+      if (!t.isVariableDeclarator(path.parent)) return;
 
-			// skip function calls where the return value is not Array-destructured:
-			if (!t.isArrayPattern(path.parent.id)) return;
+      // skip function calls where the return value is not Array-destructured:
+      if (!t.isArrayPattern(path.parent.id)) return;
 
-			// name of the (hook) function being called:
-			if (!t.isIdentifier(path.node.callee)) return;
-			const hookName = path.node.callee.name;
+      // name of the (hook) function being called:
+      if (!t.isIdentifier(path.node.callee)) return;
+      const hookName = path.node.callee.name;
 
-			if (libs) {
-				const binding = path.scope.getBinding(hookName);
+      if (libs) {
+        const binding = path.scope.getBinding(hookName);
 
-				// not an import
+        // not an import
         if (!binding || binding.kind !== 'module' || !t.isImportDeclaration(binding.path.parent)) return;
         
-				const specifier = binding.path.parent.source.value;
-				// not a match
-				if (!libs.includes(specifier)) return;
-			}
+        const specifier = binding.path.parent.source.value;
+        // not a match
+        if (!libs.includes(specifier)) return;
+      }
 
-			// only match function calls with names that look like a hook
-			if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
+      // only match function calls with names that look like a hook
+      if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
 
-			path.parent.id = t.objectPattern(
-				path.parent.id.elements.reduce((acc, element, i) => {
-					if (element) {
-						acc.push(t.objectProperty(t.numericLiteral(i), t.clone(element)));
-					}
-					return acc;
-				}, [])
-			);
-		},
-	};
+      path.parent.id = t.objectPattern(
+        path.parent.id.elements.reduce((acc, element, i) => {
+          if (element) {
+            acc.push(t.objectProperty(t.numericLiteral(i), t.clone(element)));
+          }
+          return acc;
+        }, [])
+      );
+    }
+  };
 
-	return {
-		name: 'optimize-hook-destructuring',
-		visitor: {
-			// this is a workaround to run before preset-env destroys destructured assignments
-			Program(path) {
-				path.traverse(visitor);
-			}
-		}
-	};
+  return {
+    name: 'optimize-hook-destructuring',
+    visitor: {
+      // this is a workaround to run before preset-env destroys destructured assignments
+      Program(path) {
+        path.traverse(visitor);
+      }
+    }
+  };
 };

--- a/index.js
+++ b/index.js
@@ -2,47 +2,68 @@
 const isHook = /^use[A-Z]/;
 
 // matches only built-in hooks provided by React et al
-const isBuiltInHook = /^use(Callback|Context|DebugValue|Effect|ImperativeHandle|LayoutEffect|Memo|Reducer|Ref|State)$/;
+const isBuiltInHook = /^use(?:Callback|Context|DebugValue|Effect|ImperativeHandle|LayoutEffect|Memo|Reducer|Ref|State)$/;
 
-module.exports = (babel, options) => {
+/**
+ * @typedef Options
+ * @property {boolean|string} [lib=false] If specified, only hook functions imported from this module are processed. Pass `true` to include 'react' and 'preact/hooks'.
+ * @property {boolean} [onlyBuiltIns=false] Only optimize known built-in hooks from react/preact.
+ */
 
-  const { types: t } = babel;
-  const onlyBuiltIns = options && options.onlyBuiltIns;
+/**
+ * @param {import('@babel/core')} api
+ * @param {Options} [options]
+ * @returns {import('@babel/core').PluginObj}
+ */
+module.exports = ({ types: t }, /** @type {Options} */ options = {}) => {
+	const libs = options.lib && (options.lib === true ? ['react', 'preact/hooks'] : [options.lib]);
+	const onlyBuiltIns = options.onlyBuiltIns || false;
 
-  // if specified, options.lib is a list of libraries that provide hook functions
-  const libs = options && options.lib && (
-    options.lib === true ? ['react', 'preact/hooks'] : [].concat(options.lib)
-  );
+	/** @type {import('@babel/core').Visitor} */
+	const visitor = {
+		CallExpression(path) {
+			// skip function calls that are not the init of a variable declaration:
+			if (!t.isVariableDeclarator(path.parent)) return;
 
-  return {
-    name: "optimize-hook-destructuring",
-    visitor: {
-      CallExpression(path) {
-        // skip function calls where the return value is not Array-destructured:
-        if (!t.isArrayPattern(path.parent.id)) return;
+			// skip function calls where the return value is not Array-destructured:
+			if (!t.isArrayPattern(path.parent.id)) return;
 
-        // name of the (hook) function being called:
-        const hookName = path.node.callee.name;
+			// name of the (hook) function being called:
+			if (!t.isIdentifier(path.node.callee)) return;
+			const hookName = path.node.callee.name;
 
-        if (libs) {
-          const binding = path.scope.getBinding(hookName);
-          // not an import
-          if (!binding || binding.kind !== 'module') return;
+			if (libs) {
+				const binding = path.scope.getBinding(hookName);
 
-          const specifier = binding.path.parent.source.value;
-          // not a match
-          if (!libs.some(lib => lib === specifier)) return;
-        }
+				// not an import
+        if (!binding || binding.kind !== 'module' || !t.isImportDeclaration(binding.path.parent)) return;
         
-        // only match function calls with names that look like a hook
-        if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
-        
-        path.parent.id = t.objectPattern(
-          path.parent.id.elements.map((element, i) =>
-            t.objectProperty(t.numericLiteral(i), element)
-          )
-        );
-      }
-    }
-  };
+				const specifier = binding.path.parent.source.value;
+				// not a match
+				if (!libs.includes(specifier)) return;
+			}
+
+			// only match function calls with names that look like a hook
+			if (!(onlyBuiltIns ? isBuiltInHook : isHook).test(hookName)) return;
+
+			path.parent.id = t.objectPattern(
+				path.parent.id.elements.reduce((acc, element, i) => {
+					if (element) {
+						acc.push(t.objectProperty(t.numericLiteral(i), t.clone(element)));
+					}
+					return acc;
+				}, [])
+			);
+		},
+	};
+
+	return {
+		name: 'optimize-hook-destructuring',
+		visitor: {
+			// this is a workaround to run before preset-env destroys destructured assignments
+			Program(path) {
+				path.traverse(visitor);
+			},
+		},
+	};
 };


### PR DESCRIPTION
Hiya! This ended up getting forked and rewritten in TS for both Next.js and Gatsby. Ideally it'd be nice to have them instead use the same transform so that it can be maintained in a single place. I've added strict typing via JSDoc and included a bugfix for holey destructuring (`[,,c]`) Gatsby added.